### PR TITLE
Fix scan_file (upload to VT), do not leak full path.

### DIFF
--- a/virus_total_apis/api.py
+++ b/virus_total_apis/api.py
@@ -68,7 +68,7 @@ class PublicApi():
         params = {'apikey': self.api_key}
         try:
             if os.path.isfile(this_file):
-                files = {'file': (this_file, open(this_file, 'rb'))}
+                files = {'file': (os.path.basename(this_file), open(this_file, 'rb').read())}
             elif isinstance(this_file, StringIO.StringIO):
                 files = {'file': this_file.read()}
             else:


### PR DESCRIPTION
Leaking the full path on the computer of the analyst is mostly useless, only sending the file name.