### PR TITLE
Update api.py

### DIFF
--- a/virus_total_apis/api.py
+++ b/virus_total_apis/api.py
@@ -21,6 +21,7 @@ print json.dumps(response, sort_keys=False, indent=4)
 """
 
 import os
+import json
 from datetime import datetime, timedelta
 
 try:
@@ -921,7 +922,7 @@ class IntelApi():
         :param timeout: The amount of time in seconds the request should wait before timing out.
         :returns: The next page identifier, The results (JSON is possible with .json())
         """
-        params = {'apikey': self.api_key, 'page': page}
+        params = {'apikey': self.api_key, 'next': page}
         try:
             response = requests.get(self.base + 'hunting/notifications-feed/',
                                     params=params,
@@ -940,12 +941,13 @@ class IntelApi():
         if not isinstance(ids, list):
             raise TypeError("ids must be a list")
 
-        params = {'apikey': self.api_key, 'id': ids}
+        # VirusTotal needs ids as a stringified array
+        data = json.dumps(ids)
 
         try:
             response = requests.post(
-                self.base + 'hunting/delete-notifications/programmatic/',
-                params=params,
+                self.base + 'hunting/delete-notifications/programmatic/?key=' + self.api_key,
+                data=data,
                 proxies=self.proxies,
                 timeout=timeout)
         except requests.RequestException as e:


### PR DESCRIPTION
In `get_intel_notifications_feed` the GET parameter `page` must be `next`. Using `page` with the next token will return the same results (as if `page` parameter is ignored). `next` correctly gets the next set of notifications.

In `delete_intel_notifications` the list of ids must be sent in as a stringified JSON array. This is sent in as the `data` field in `requests.post()` instead of the `params` dict and the `api_key` is sent as a GET parameter in they URL as `key`. It may work another way, but we deduced this from analyzing the network calls while doing this on the website in Firefox's developer tools. Otherwise the response would always be `u'{"deleted": 0, "received": 0, "result": -1}'`.