### PR TITLE
Unicode-objects must be encoded before hashing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Usage
 
     API_KEY = 'Sign-Up for API Key at virustotal.com'
 
-    EICAR = "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*"
+    EICAR = "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*".encode('utf-8')
     EICAR_MD5 = hashlib.md5(EICAR).hexdigest()
 
     vt = VirusTotalPublicApi(API_KEY)


### PR DESCRIPTION
Copy and paste the example code into my Jupyter Notebook created the following error: 

_Unicode-objects must be encoded before hashing_. 

Adding the relevant encoding to the test string solved the problem. So I've changed this line:
`` 
EICAR = "X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*".encode('utf-8')
``